### PR TITLE
Fix rendering of long_description on PyPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -92,6 +92,7 @@ setup(
     license='BSD-2-Clause',
     description='An example Python package written in x86-64 assembly.',
     long_description= read('README.md'),
+    long_description_content_type='text/markdown',
     author='Anthony Shaw',
     author_email='anthonyshaw@apache.org',
     url='https://github.com/tonybaloney/python-assembly-poc',


### PR DESCRIPTION
Hi, 

The project description on PyPI hasn't rendered properly, because PyPI assumes the content of `long_description` is reStructuredText unless told otherwise. This change will fix the rendering.